### PR TITLE
[3] Fix Lint Errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG] Bug Title"
+title: '[BUG] Bug Title'
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,10 +11,11 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. Run 'yarn ...' 
+4. Run 'yarn ...'
 5. See error
 
 **Expected behavior**
@@ -25,11 +25,12 @@ A clear and concise description of what you expected to happen.
 [Optional] If applicable, add screenshots to help explain your problem.
 
 **Dev Env (please complete the following information):**
- - OS: e.g. 'Ubuntu 24.04'
- - Node version (`node --version`):
- - Nvm version (`nvm --version`):  
- - Docker version (`docker --version`): 
- - commit hash (`git log`): 
+
+- OS: e.g. 'Ubuntu 24.04'
+- Node version (`node --version`):
+- Nvm version (`nvm --version`):
+- Docker version (`docker --version`):
+- commit hash (`git log`):
 
 **Additional Info**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[REQUEST] Request title"
+title: '[REQUEST] Request title'
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a critical gap/problem or an enhancement? Please describe.**

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,12 +3,13 @@ import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 import { defineConfig } from 'eslint/config';
+import type { Linter } from 'eslint';
 
 // Collect ONLY the rules from recommendedTypeChecked (so we can scope them)
-const typeCheckedRules = tseslint.configs.recommendedTypeChecked.reduce<Record<string, any>>(
-  (acc, cfg) => Object.assign(acc, cfg.rules ?? {}),
-  {},
-);
+const typeCheckedRules: Linter.RulesRecord = {};
+for (const cfg of tseslint.configs.recommendedTypeChecked) {
+  if (cfg.rules) Object.assign(typeCheckedRules, cfg.rules);
+}
 
 export default defineConfig([
   // ignore build artifacts
@@ -53,6 +54,23 @@ export default defineConfig([
       '@typescript-eslint/no-explicit-any': 'warn',
       // Run Prettier as an ESLint rule (reports formatting as errors)
       'prettier/prettier': 'error',
+    },
+  },
+
+  // Tests only: allow underscore-prefixed unused args
+  {
+    files: ['test/**/*.ts'],
+    rules: {
+      // keep variable checks, but ignore args/caught errors that start with "_"
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,17 +4,40 @@ import prettierConfig from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 import { defineConfig } from 'eslint/config';
 
+// Collect ONLY the rules from recommendedTypeChecked (so we can scope them)
+const typeCheckedRules = tseslint.configs.recommendedTypeChecked.reduce<Record<string, any>>(
+  (acc, cfg) => Object.assign(acc, cfg.rules ?? {}),
+  {},
+);
+
 export default defineConfig([
   // ignore build artifacts
   { ignores: ['dist', 'node_modules', 'coverage'] },
 
+  // Base JS rules
   js.configs.recommended,
-  // TypeScript recommended **type-checked** rules
-  // (requires parserOptions.project)
-  ...tseslint.configs.recommendedTypeChecked,
+  // Base TS rules (non type-aware) for ALL .ts, including config files
+  ...tseslint.configs.recommended,
 
+  // 1) Config files FIRST: lint w/o type info
   {
-    files: ['**/*.ts', '**/*.tsx'],
+    files: ['eslint.config.ts', 'jest.config.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        // no `project` here -> parses without type info
+        project: false,
+      },
+    },
+    plugins: { prettier: prettierPlugin },
+    rules: {
+      'prettier/prettier': 'error',
+    },
+  },
+
+  // 2) Typed rules ONLY for src + test
+  {
+    files: ['src/**/*.ts', 'test/**/*.tsx'],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
@@ -23,8 +46,9 @@ export default defineConfig([
         tsconfigRootDir: process.cwd(),
       },
     },
-    plugins: { prettier: prettierPlugin },
+    plugins: { '@typescript-eslint': tseslint.plugin, prettier: prettierPlugin },
     rules: {
+      ...typeCheckedRules,
       // keep 'any' as a warning for now
       '@typescript-eslint/no-explicit-any': 'warn',
       // Run Prettier as an ESLint rule (reports formatting as errors)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
-import { serviceImpl } from './service';
 import path from 'path';
 import dotenv from 'dotenv';
+import { serviceImpl } from './service';
+import { mapCcxtErrorToGrpc } from './utils';
 
 dotenv.config();
 
 const PROTO_PATH = path.resolve(__dirname, '../proto/ccxt.proto');
 
-const packageDef = protoLoader.loadSync(PROTO_PATH, {
+const packageDef: protoLoader.PackageDefinition = protoLoader.loadSync(PROTO_PATH, {
   keepCase: true,
   longs: String,
   enums: String,
@@ -16,36 +17,74 @@ const packageDef = protoLoader.loadSync(PROTO_PATH, {
   oneofs: true,
 });
 
-const proto = grpc.loadPackageDefinition(packageDef) as any;
+// Loaded packages are untyped; treat as a generic GrpcObject.
+const loaded: grpc.GrpcObject = grpc.loadPackageDefinition(packageDef);
 
-function main() {
+// Reach into our package and pull out the service definition, staying type-safe.
+const ccxtmicro = loaded.ccxtmicro as grpc.GrpcObject;
+const CcxtService = ccxtmicro.CcxtService as unknown as {
+  service: grpc.ServiceDefinition<grpc.UntypedServiceImplementation>;
+};
+
+/**
+ * Wrap an async unary handler so it satisfies `handleUnaryCall`'s `void` return
+ * and avoids `@typescript-eslint/no-misused-promises`.
+ */
+function wrapUnary(
+  fn: (
+    call: grpc.ServerUnaryCall<unknown, unknown>,
+    cb: grpc.sendUnaryData<unknown>,
+  ) => Promise<void> | void,
+): grpc.handleUnaryCall<unknown, unknown> {
+  return (call, cb) => {
+    try {
+      const maybePromise = fn(call, cb);
+      if (maybePromise && typeof (maybePromise as Promise<unknown>).catch === 'function') {
+        void (maybePromise as Promise<unknown>).catch((e) => {
+          // Last-resort error path if handler threw before calling `cb`
+          const { code, message } = mapCcxtErrorToGrpc(e);
+          cb({ code, message } as never, null as never);
+        });
+      }
+    } catch (e) {
+      const { code, message } = mapCcxtErrorToGrpc(e);
+      cb({ code, message } as never, null as never);
+    }
+  };
+}
+
+function main(): void {
   const server = new grpc.Server();
-  server.addService(proto.ccxtmicro.CcxtService.service, {
-    loadMarkets: serviceImpl.loadMarkets,
-    fetchMarkets: serviceImpl.fetchMarkets,
-    fetchCurrencies: serviceImpl.fetchCurrencies,
-    fetchTicker: serviceImpl.fetchTicker,
-    fetchTickers: serviceImpl.fetchTickers,
-    fetchOrderBook: serviceImpl.fetchOrderBook,
-    fetchOHLCV: serviceImpl.fetchOHLCV,
-    fetchStatus: serviceImpl.fetchStatus,
-    fetchTrades: serviceImpl.fetchTrades,
-    fetchBalance: serviceImpl.fetchBalance,
-    fetchOrder: serviceImpl.fetchOrder,
-    fetchOrders: serviceImpl.fetchOrders,
-    fetchOpenOrders: serviceImpl.fetchOpenOrders,
-    fetchClosedOrders: serviceImpl.fetchClosedOrders,
-    fetchMyTrades: serviceImpl.fetchMyTrades,
-    createOrder: serviceImpl.createOrder,
-    cancelOrder: serviceImpl.cancelOrder,
-    deposit: serviceImpl.deposit,
-    withdraw: serviceImpl.withdraw,
-  });
+
+  // Provide an UntypedServiceImplementation with void-returning handlers.
+  const handlers: grpc.UntypedServiceImplementation = {
+    loadMarkets: wrapUnary(serviceImpl.loadMarkets as unknown as any),
+    fetchMarkets: wrapUnary(serviceImpl.fetchMarkets as unknown as any),
+    fetchCurrencies: wrapUnary(serviceImpl.fetchCurrencies as unknown as any),
+    fetchTicker: wrapUnary(serviceImpl.fetchTicker as unknown as any),
+    fetchTickers: wrapUnary(serviceImpl.fetchTickers as unknown as any),
+    fetchOrderBook: wrapUnary(serviceImpl.fetchOrderBook as unknown as any),
+    fetchOHLCV: wrapUnary(serviceImpl.fetchOHLCV as unknown as any),
+    fetchStatus: wrapUnary(serviceImpl.fetchStatus as unknown as any),
+    fetchTrades: wrapUnary(serviceImpl.fetchTrades as unknown as any),
+    fetchBalance: wrapUnary(serviceImpl.fetchBalance as unknown as any),
+    fetchOrder: wrapUnary(serviceImpl.fetchOrder as unknown as any),
+    fetchOrders: wrapUnary(serviceImpl.fetchOrders as unknown as any),
+    fetchOpenOrders: wrapUnary(serviceImpl.fetchOpenOrders as unknown as any),
+    fetchClosedOrders: wrapUnary(serviceImpl.fetchClosedOrders as unknown as any),
+    fetchMyTrades: wrapUnary(serviceImpl.fetchMyTrades as unknown as any),
+    createOrder: wrapUnary(serviceImpl.createOrder as unknown as any),
+    cancelOrder: wrapUnary(serviceImpl.cancelOrder as unknown as any),
+    deposit: wrapUnary(serviceImpl.deposit as unknown as any),
+    withdraw: wrapUnary(serviceImpl.withdraw as unknown as any),
+  };
+
+  server.addService(CcxtService.service, handlers);
 
   const port = process.env.PORT ? Number(process.env.PORT) : 50051;
   const addr = `0.0.0.0:${port}`;
 
-  server.bindAsync(addr, grpc.ServerCredentials.createInsecure(), (err, boundPort) => {
+  server.bindAsync(addr, grpc.ServerCredentials.createInsecure(), (err) => {
     if (err) {
       console.error('Failed to bind:', err);
       process.exit(1);

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,284 +1,387 @@
-import { sendUnaryData, ServerUnaryCall, status } from '@grpc/grpc-js';
+import type { sendUnaryData, ServerUnaryCall } from '@grpc/grpc-js';
+import { status } from '@grpc/grpc-js';
 import { createExchange } from './exchangeFactory';
 import { asGrpcValue, mapCcxtErrorToGrpc, toOhlcv } from './utils';
-import { ExchangeLike } from './types';
+import type {
+  Credentials,
+  ExchangeConfig,
+  ExchangeLike,
+  JsonValue,
+  OhlcvEntry,
+  Params,
+} from './types';
 
-// Type aliases for request shapes that match proto-loader outputs
-type AnyReq = { request: any };
+/* ------------------------ Request / Response typings ----------------------- */
+
+class InvalidArgumentsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidArguments';
+  }
+}
+
+type StructMessage = { value?: Params };
+
+type BaseReq = {
+  config: ExchangeConfig;
+  credentials?: Credentials;
+  params?: StructMessage;
+};
+
+type LoadMarketsRequest = BaseReq & { reload?: boolean };
+
+type SymbolRequest = BaseReq & { symbol: string };
+type SymbolsRequest = BaseReq & { symbols?: string[] };
+
+type OrderBookRequest = BaseReq & { symbol: string; limit?: number };
+
+type OHLCVRequest = BaseReq & {
+  symbol: string;
+  timeframe?: string;
+  since?: number;
+  limit?: number;
+};
+
+type TradesRequest = BaseReq & {
+  symbol: string;
+  since?: number;
+  limit?: number;
+};
+
+type FetchOrderRequest = BaseReq & { id: string; symbol?: string };
+type FetchOrdersRequest = BaseReq & { symbol?: string; since?: number; limit?: number };
+
+type CreateOrderRequest = BaseReq & {
+  symbol: string;
+  type: string;
+  side: string;
+  amount: number;
+  price?: number;
+};
+
+type CancelOrderRequest = BaseReq & { id: string; symbol?: string };
+
+type TransferRequest = BaseReq & {
+  code: string;
+  amount: number;
+  address: string;
+  tag?: string;
+};
+
+type GenericResponse = { data: JsonValue };
+type FetchOHLCVResponse = { candles: OhlcvEntry[] };
+
+/* --------------------------------- Helpers -------------------------------- */
+
+function paramsOf(req: { params?: StructMessage }): Params | undefined {
+  return req.params?.value;
+}
+
+function ensureExchange<R extends BaseReq>(call: ServerUnaryCall<R, unknown>): ExchangeLike {
+  const { config, credentials } = call.request;
+  if (!config?.exchange) {
+    throw new InvalidArgumentsError('config.exchange is required');
+  }
+  return createExchange(config, credentials);
+}
+
+function ok<T>(cb: sendUnaryData<T>, payload: T) {
+  cb(null, payload);
+}
+
+function fail<T>(cb: sendUnaryData<T>, err: unknown) {
+  const mapped = mapCcxtErrorToGrpc(err);
+  cb({ code: mapped.code, message: mapped.message } as never, null as never);
+}
+
+/* --------------------------------- Service -------------------------------- */
 
 export class CcxtServiceImpl {
-  private getExchange(call: AnyReq): ExchangeLike {
-    const { config, credentials } = call.request;
-    if (!config?.exchange) {
-      throw { name: 'InvalidArguments', message: 'config.exchange is required' };
-    }
-    return createExchange(config, credentials);
-  }
-
-  private ok<T>(callback: sendUnaryData<T>, payload: T) {
-    callback(null, payload);
-  }
-
-  private fail<T>(callback: sendUnaryData<T>, err: any) {
-    const mapped = mapCcxtErrorToGrpc(err);
-    callback({ code: mapped.code, message: mapped.message } as any, null as any);
-  }
-
-  loadMarkets = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  loadMarkets = async (
+    call: ServerUnaryCall<LoadMarketsRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const ex = this.getExchange(call as AnyReq);
-      const { reload, params } = call.request;
-      const data = await ex.loadMarkets(reload, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const data = await ex.loadMarkets(Boolean(call.request.reload), paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchMarkets = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchMarkets = async (
+    call: ServerUnaryCall<BaseReq, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchMarkets(call.request?.params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const data = await ex.fetchMarkets(paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchCurrencies = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchCurrencies = async (
+    call: ServerUnaryCall<BaseReq, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchCurrencies(call.request?.params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const data = await ex.fetchCurrencies(paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchTicker = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchTicker = async (
+    call: ServerUnaryCall<SymbolRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { symbol, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchTicker(symbol, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const data = await ex.fetchTicker(call.request.symbol, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchTickers = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchTickers = async (
+    call: ServerUnaryCall<SymbolsRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { symbols, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchTickers(symbols?.length ? symbols : undefined, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const syms =
+        call.request.symbols && call.request.symbols.length ? call.request.symbols : undefined;
+      const data = await ex.fetchTickers(syms, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchOrderBook = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchOrderBook = async (
+    call: ServerUnaryCall<OrderBookRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { symbol, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchOrderBook(symbol, limit || undefined, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
-    } catch (err) {
-      this.fail(callback, err);
-    }
-  };
-
-  fetchOHLCV = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
-    try {
-      const { symbol, timeframe, since, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchOHLCV(
-        symbol,
-        timeframe || undefined,
-        since || undefined,
-        limit || undefined,
-        params?.value,
+      const ex = ensureExchange(call);
+      const data = await ex.fetchOrderBook(
+        call.request.symbol,
+        call.request.limit,
+        paramsOf(call.request),
       );
-      this.ok(callback, { candles: toOhlcv(data) });
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchStatus = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchOHLCV = async (
+    call: ServerUnaryCall<OHLCVRequest, FetchOHLCVResponse>,
+    cb: sendUnaryData<FetchOHLCVResponse>,
+  ) => {
     try {
-      const ex = this.getExchange(call as AnyReq);
+      const ex = ensureExchange(call);
+      const { symbol, timeframe, since, limit } = call.request;
+      const rows = await ex.fetchOHLCV(symbol, timeframe, since, limit, paramsOf(call.request));
+      ok(cb, { candles: toOhlcv(rows) });
+    } catch (err) {
+      fail(cb, err);
+    }
+  };
+
+  fetchStatus = async (
+    call: ServerUnaryCall<BaseReq, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
+    try {
+      const ex = ensureExchange(call);
       if (!ex.fetchStatus) {
-        return callback(
+        return cb(
           {
             code: status.UNIMPLEMENTED,
             message: 'fetchStatus not supported by this exchange',
-          } as any,
-          null as any,
+          } as never,
+          null as never,
         );
       }
-      const data = await ex.fetchStatus(call.request?.params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const data = await ex.fetchStatus(paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchTrades = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchTrades = async (
+    call: ServerUnaryCall<TradesRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { symbol, since, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchTrades(
-        symbol,
-        since || undefined,
-        limit || undefined,
-        params?.value,
+      const ex = ensureExchange(call);
+      const { symbol, since, limit } = call.request;
+      const data = await ex.fetchTrades(symbol, since, limit, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
+    } catch (err) {
+      fail(cb, err);
+    }
+  };
+
+  fetchBalance = async (
+    call: ServerUnaryCall<BaseReq, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
+    try {
+      const ex = ensureExchange(call);
+      const data = await ex.fetchBalance(paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
+    } catch (err) {
+      fail(cb, err);
+    }
+  };
+
+  fetchOrder = async (
+    call: ServerUnaryCall<FetchOrderRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
+    try {
+      const ex = ensureExchange(call);
+      const data = await ex.fetchOrder(
+        call.request.id,
+        call.request.symbol,
+        paramsOf(call.request),
       );
-      this.ok(callback, { data: asGrpcValue(data) });
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchBalance = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchOrders = async (
+    call: ServerUnaryCall<FetchOrdersRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchBalance(call.request?.params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const { symbol, since, limit } = call.request;
+      const data = await ex.fetchOrders(symbol, since, limit, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchOrder = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchOpenOrders = async (
+    call: ServerUnaryCall<FetchOrdersRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { id, symbol, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchOrder(id, symbol || undefined, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const { symbol, since, limit } = call.request;
+      const data = await ex.fetchOpenOrders(symbol, since, limit, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchOrders = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  fetchClosedOrders = async (
+    call: ServerUnaryCall<FetchOrdersRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { symbol, since, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchOrders(
-        symbol || undefined,
-        since || undefined,
-        limit || undefined,
-        params?.value,
+      const ex = ensureExchange(call);
+      const { symbol, since, limit } = call.request;
+      const data = await ex.fetchClosedOrders(symbol, since, limit, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
+    } catch (err) {
+      fail(cb, err);
+    }
+  };
+
+  fetchMyTrades = async (
+    call: ServerUnaryCall<FetchOrdersRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
+    try {
+      const ex = ensureExchange(call);
+      const { symbol, since, limit } = call.request;
+      const data = await ex.fetchMyTrades(symbol, since, limit, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
+    } catch (err) {
+      fail(cb, err);
+    }
+  };
+
+  createOrder = async (
+    call: ServerUnaryCall<CreateOrderRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
+    try {
+      const ex = ensureExchange(call);
+      const { symbol, type, side, amount, price } = call.request;
+      const data = await ex.createOrder(symbol, type, side, amount, price, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
+    } catch (err) {
+      fail(cb, err);
+    }
+  };
+
+  cancelOrder = async (
+    call: ServerUnaryCall<CancelOrderRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
+    try {
+      const ex = ensureExchange(call);
+      const data = await ex.cancelOrder(
+        call.request.id,
+        call.request.symbol,
+        paramsOf(call.request),
       );
-      this.ok(callback, { data: asGrpcValue(data) });
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  fetchOpenOrders = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  deposit = async (
+    call: ServerUnaryCall<TransferRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { symbol, since, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchOpenOrders(
-        symbol || undefined,
-        since || undefined,
-        limit || undefined,
-        params?.value,
-      );
-      this.ok(callback, { data: asGrpcValue(data) });
-    } catch (err) {
-      this.fail(callback, err);
-    }
-  };
-
-  fetchClosedOrders = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
-    try {
-      const { symbol, since, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchClosedOrders(
-        symbol || undefined,
-        since || undefined,
-        limit || undefined,
-        params?.value,
-      );
-      this.ok(callback, { data: asGrpcValue(data) });
-    } catch (err) {
-      this.fail(callback, err);
-    }
-  };
-
-  fetchMyTrades = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
-    try {
-      const { symbol, since, limit, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.fetchMyTrades(
-        symbol || undefined,
-        since || undefined,
-        limit || undefined,
-        params?.value,
-      );
-      this.ok(callback, { data: asGrpcValue(data) });
-    } catch (err) {
-      this.fail(callback, err);
-    }
-  };
-
-  createOrder = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
-    try {
-      const { symbol, type, side, amount, price, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.createOrder(
-        symbol,
-        type,
-        side,
-        amount,
-        price || undefined,
-        params?.value,
-      );
-      this.ok(callback, { data: asGrpcValue(data) });
-    } catch (err) {
-      this.fail(callback, err);
-    }
-  };
-
-  cancelOrder = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
-    try {
-      const { id, symbol, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.cancelOrder(id, symbol || undefined, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
-    } catch (err) {
-      this.fail(callback, err);
-    }
-  };
-
-  deposit = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
-    try {
-      const { code, amount, address, tag, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
+      const ex = ensureExchange(call);
       if (!ex.deposit) {
-        return callback(
-          { code: status.UNIMPLEMENTED, message: 'deposit not supported by this exchange' } as any,
-          null as any,
+        return cb(
+          {
+            code: status.UNIMPLEMENTED,
+            message: 'deposit not supported by this exchange',
+          } as never,
+          null as never,
         );
       }
-      const data = await ex.deposit(code, amount, address, tag || undefined, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const { code, amount, address, tag } = call.request;
+      const data = await ex.deposit(code, amount, address, tag, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 
-  withdraw = async (call: ServerUnaryCall<any, any>, callback: sendUnaryData<any>) => {
+  withdraw = async (
+    call: ServerUnaryCall<TransferRequest, GenericResponse>,
+    cb: sendUnaryData<GenericResponse>,
+  ) => {
     try {
-      const { code, amount, address, tag, params } = call.request;
-      const ex = this.getExchange(call as AnyReq);
-      const data = await ex.withdraw(code, amount, address, tag || undefined, params?.value);
-      this.ok(callback, { data: asGrpcValue(data) });
+      const ex = ensureExchange(call);
+      const { code, amount, address, tag } = call.request;
+      const data = await ex.withdraw(code, amount, address, tag, paramsOf(call.request));
+      ok(cb, { data: asGrpcValue(data) });
     } catch (err) {
-      this.fail(callback, err);
+      fail(cb, err);
     }
   };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,37 +1,45 @@
 import { status } from '@grpc/grpc-js';
+import type { JsonValue, OhlcvEntry } from './types';
 
-export function asGrpcValue(data: any): any {
-  // With @grpc/proto-loader, plain JS maps cleanly to google.protobuf.Value
-  // so we just return the data.
+/**
+ * Map JS -> google.protobuf.Value-compatible.
+ * Note: protobuf Value cannot carry `undefined`, so we coerce it to `null`.
+ */
+export function asGrpcValue<T extends JsonValue>(data: T | undefined): T | null {
   return data === undefined ? null : data;
 }
 
-export function mapCcxtErrorToGrpc(err: any): { code: number; message: string } {
-  const name = err?.name || '';
-  const message = err?.message || 'Unknown error';
+type ErrorLike = { name?: unknown; message?: unknown };
 
-  // Generic mappings (subset of ccxt exceptions)
-  if (name.includes('Authentication')) return { code: status.UNAUTHENTICATED, message };
-  if (name.includes('Permission')) return { code: status.PERMISSION_DENIED, message };
-  if (name.includes('Invalid')) return { code: status.INVALID_ARGUMENT, message };
-  if (name.includes('NotSupported') || name.includes('NotImplemented'))
-    return { code: status.UNIMPLEMENTED, message };
-  if (name.includes('OrderNotFound')) return { code: status.NOT_FOUND, message };
-  if (name.includes('InsufficientFunds')) return { code: status.FAILED_PRECONDITION, message };
-  if (name.includes('DDoS') || name.includes('Network') || name.includes('RequestTimeout'))
-    return { code: status.UNAVAILABLE, message };
+/** Convert a thrown value to gRPC status + message without using `any`. */
+export function mapCcxtErrorToGrpc(err: unknown): { code: number; message: string } {
+  const { name, message } =
+    typeof err === 'object' && err !== null ? (err as ErrorLike) : ({} as ErrorLike);
 
-  // Fallback
-  return { code: status.UNKNOWN, message };
+  const nameStr = typeof name === 'string' ? name : '';
+  const msgStr = typeof message === 'string' ? message : 'Unknown error';
+
+  if (nameStr.includes('Authentication')) return { code: status.UNAUTHENTICATED, message: msgStr };
+  if (nameStr.includes('Permission')) return { code: status.PERMISSION_DENIED, message: msgStr };
+  if (nameStr.includes('Invalid')) return { code: status.INVALID_ARGUMENT, message: msgStr };
+  if (nameStr.includes('NotSupported') || nameStr.includes('NotImplemented'))
+    return { code: status.UNIMPLEMENTED, message: msgStr };
+  if (nameStr.includes('OrderNotFound')) return { code: status.NOT_FOUND, message: msgStr };
+  if (nameStr.includes('InsufficientFunds'))
+    return { code: status.FAILED_PRECONDITION, message: msgStr };
+  if (nameStr.includes('DDoS') || nameStr.includes('Network') || nameStr.includes('RequestTimeout'))
+    return { code: status.UNAVAILABLE, message: msgStr };
+
+  return { code: status.UNKNOWN, message: msgStr };
 }
 
-export function toOhlcv(entries: number[][]) {
-  return (entries || []).map((c) => ({
-    timestamp: Math.trunc(c[0] || 0),
-    open: Number(c[1] || 0),
-    high: Number(c[2] || 0),
-    low: Number(c[3] || 0),
-    close: Number(c[4] || 0),
-    volume: Number(c[5] || 0),
+export function toOhlcv(entries: ReadonlyArray<ReadonlyArray<number>>): OhlcvEntry[] {
+  return (entries ?? []).map((c) => ({
+    timestamp: Math.trunc(c[0] ?? 0),
+    open: Number(c[1] ?? 0),
+    high: Number(c[2] ?? 0),
+    low: Number(c[3] ?? 0),
+    close: Number(c[4] ?? 0),
+    volume: Number(c[5] ?? 0),
   }));
 }

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,235 +1,251 @@
-/**
- * Unit tests for all gRPC handlers using a mocked exchange factory.
- * We directly invoke the handler methods with fake call/callback.
- */
-
+// test/service.test.ts
 import { serviceImpl } from '../src/service';
+import type {
+  ExchangeConfig,
+  Credentials,
+  ExchangeLike,
+  JsonValue,
+  Params,
+  OhlcvEntry,
+  OrderBook,
+  OhlcvTuple,
+} from '../src/types';
+import type { ServerUnaryCall, sendUnaryData, ServiceError } from '@grpc/grpc-js';
 
-// Mock the exchange factory to return a stubbed exchange for every call.
-jest.mock('../src/exchangeFactory', () => {
-  const makeExchange = () => ({
-    loadMarkets: jest.fn(async (_reload?: boolean, _p?: any) => ({ loaded: true })),
-    fetchMarkets: jest.fn(async (_p?: any) => [{ symbol: 'BTC/USDT' }]),
-    fetchCurrencies: jest.fn(async (_p?: any) => ({ BTC: {}, USDT: {} })),
-    fetchTicker: jest.fn(async (_s: string, _p?: any) => ({ symbol: 'BTC/USDT', last: 65000 })),
-    fetchTickers: jest.fn(async (_ss?: string[], _p?: any) => ({
+/* ----------------------------- Exchange mock ------------------------------ */
+
+const mockExchange: ExchangeLike = {
+  loadMarkets: jest.fn(
+    async (_reload?: boolean, _p?: Params): Promise<JsonValue> => ({ loaded: true }),
+  ),
+  fetchMarkets: jest.fn(async (_p?: Params): Promise<JsonValue> => [{ symbol: 'BTC/USDT' }]),
+  fetchCurrencies: jest.fn(async (_p?: Params): Promise<JsonValue> => ({ BTC: {}, USDT: {} })),
+  fetchTicker: jest.fn(
+    async (_s: string, _p?: Params): Promise<JsonValue> => ({ symbol: 'BTC/USDT', last: 65000 }),
+  ),
+  fetchTickers: jest.fn(
+    async (_ss?: readonly string[], _p?: Params): Promise<JsonValue> => ({
       'BTC/USDT': { last: 65000 },
       'ETH/USDT': { last: 3000 },
-    })),
-    fetchOrderBook: jest.fn(async (_s: string, _l?: number, _p?: any) => ({
-      bids: [[65000, 1]],
-      asks: [[65100, 2]],
-    })),
-    fetchOHLCV: jest.fn(
-      async (_s: string, _tf?: string, _since?: number, _limit?: number, _p?: any) => [
-        [1710000000000, 60000, 66000, 59000, 65000, 120],
-      ],
-    ),
-    fetchStatus: jest.fn(async (_p?: any) => ({ status: 'ok' })),
-    fetchTrades: jest.fn(async (_s: string, _since?: number, _limit?: number, _p?: any) => [
+    }),
+  ),
+  fetchOrderBook: jest.fn(
+    async (_s: string, _l?: number, _p?: Params): Promise<OrderBook> => ({
+      bids: [[65000, 1]] as Array<readonly [number, number]>,
+      asks: [[65100, 2]] as Array<readonly [number, number]>,
+    }),
+  ),
+  fetchOHLCV: jest.fn(
+    async (_s: string): Promise<readonly OhlcvTuple[]> => [
+      [1710000000000, 60000, 66000, 59000, 65000, 120] as const,
+    ],
+  ),
+  fetchStatus: jest.fn(async (_p?: Params): Promise<JsonValue> => ({ status: 'ok' })),
+  fetchTrades: jest.fn(
+    async (_s: string, _since?: number, _limit?: number, _p?: Params): Promise<JsonValue> => [
       { id: 't1', price: 65000, amount: 0.01 },
-    ]),
-    fetchBalance: jest.fn(async (_p?: any) => ({ total: { USDT: 1000 } })),
-    fetchOrder: jest.fn(async (_id: string, _sym?: string, _p?: any) => ({
+    ],
+  ),
+  fetchBalance: jest.fn(async (_p?: Params): Promise<JsonValue> => ({ total: { USDT: 1000 } })),
+  fetchOrder: jest.fn(
+    async (_id: string, _sym?: string, _p?: Params): Promise<JsonValue> => ({
       id: 'o1',
       status: 'open',
-    })),
-    fetchOrders: jest.fn(async (_sym?: string, _since?: number, _limit?: number, _p?: any) => [
+    }),
+  ),
+  fetchOrders: jest.fn(
+    async (_sym?: string, _since?: number, _limit?: number, _p?: Params): Promise<JsonValue> => [
       { id: 'o1' },
       { id: 'o2' },
-    ]),
-    fetchOpenOrders: jest.fn(async (_sym?: string, _since?: number, _limit?: number, _p?: any) => [
-      { id: 'o1', status: 'open' },
-    ]),
-    fetchClosedOrders: jest.fn(
-      async (_sym?: string, _since?: number, _limit?: number, _p?: any) => [
-        { id: 'o3', status: 'closed' },
-      ],
-    ),
-    fetchMyTrades: jest.fn(async (_sym?: string, _since?: number, _limit?: number, _p?: any) => [
-      { id: 'mt1', symbol: 'BTC/USDT' },
-    ]),
-    createOrder: jest.fn(
-      async (
-        _sym: string,
-        _type: string,
-        _side: string,
-        _amount: number,
-        _price?: number,
-        _p?: any,
-      ) => ({ id: 'newOrder' }),
-    ),
-    cancelOrder: jest.fn(async (_id: string, _sym?: string, _p?: any) => ({
-      id: 'o1',
-      status: 'canceled',
-    })),
-    // deposit not supported in this mock (to test UNIMPLEMENTED path)
-    withdraw: jest.fn(
-      async (_code: string, _amt: number, _addr: string, _tag?: string, _p?: any) => ({
-        id: 'w1',
-        status: 'ok',
-      }),
-    ),
-  });
+    ],
+  ),
+  fetchOpenOrders: jest.fn(async (): Promise<JsonValue> => [{ id: 'o1', status: 'open' }]),
+  fetchClosedOrders: jest.fn(async (): Promise<JsonValue> => [{ id: 'o3', status: 'closed' }]),
+  fetchMyTrades: jest.fn(async (): Promise<JsonValue> => [{ id: 'mt1', symbol: 'BTC/USDT' }]),
+  createOrder: jest.fn(async (): Promise<JsonValue> => ({ id: 'newOrder' })),
+  cancelOrder: jest.fn(async (): Promise<JsonValue> => ({ id: 'o1', status: 'canceled' })),
+  // deposit intentionally omitted to exercise UNIMPLEMENTED path
+  withdraw: jest.fn(async (): Promise<JsonValue> => ({ id: 'w1', status: 'ok' })),
+};
 
+jest.mock('../src/exchangeFactory', () => {
   return {
-    createExchange: jest.fn((_config: any, _creds: any) => makeExchange()),
+    createExchange: jest.fn(
+      (_config: ExchangeConfig, _creds?: Credentials): ExchangeLike => mockExchange,
+    ),
   };
 });
+
+/* ----------------------------- gRPC test utils ---------------------------- */
+
+type Unary<Req, Res> = (
+  call: ServerUnaryCall<Req, Res>,
+  cb: sendUnaryData<Res>,
+) => void | Promise<void>;
+
+function invoke<Req extends object, Res>(
+  handler: Unary<Req, Res>,
+  request: Req,
+): Promise<{ err: ServiceError | null; res: Res | null }> {
+  return new Promise((resolve) => {
+    const call = { request } as unknown as ServerUnaryCall<Req, Res>;
+    handler(call, (err, res) => {
+      resolve({
+        err: (err ?? null) as ServiceError | null,
+        res: (res ?? null) as Res | null,
+      });
+    });
+  });
+}
+
+/* --------------------------------- Fixtures -------------------------------- */
 
 const base = {
   config: { exchange: 'mockex', enable_rate_limit: true },
   credentials: { api_key: 'k', secret: 's' },
-  params: { value: {} },
-};
+  params: { value: {} as Params },
+} as const;
 
-function fakeCb<T>(resolve: (value: { err: any; res: T }) => void) {
-  return (err: any, res: T) => resolve({ err, res });
-}
+/* ---------------------------------- Tests ---------------------------------- */
 
 describe('CcxtServiceImpl', () => {
   test('loadMarkets', async () => {
-    const call: any = { request: { ...base, reload: true } };
-    const result = await new Promise<any>((r) => serviceImpl.loadMarkets(call, fakeCb(r)));
-    expect(result.err).toBeNull();
-    expect(result.res.data).toHaveProperty('loaded', true);
+    const req = { ...base, reload: true };
+    const { err, res } = await invoke(serviceImpl.loadMarkets, req);
+    expect(err).toBeNull();
+    expect((res as { data: JsonValue }).data).toHaveProperty('loaded', true);
   });
 
   test('fetchMarkets', async () => {
-    const call: any = { request: base };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchMarkets(call, fakeCb(r)));
+    const { err, res } = await invoke(serviceImpl.fetchMarkets, base);
     expect(err).toBeNull();
-    expect(Array.isArray(res.data)).toBe(true);
+    expect(Array.isArray((res as { data: JsonValue }).data)).toBe(true);
   });
 
   test('fetchCurrencies', async () => {
-    const { err, res } = await new Promise<any>((r) =>
-      serviceImpl.fetchCurrencies({ request: base } as any, fakeCb(r)),
-    );
+    const { err, res } = await invoke(serviceImpl.fetchCurrencies, base);
     expect(err).toBeNull();
-    expect(res.data).toHaveProperty('BTC');
+    const data = (res as { data: Record<string, unknown> }).data;
+    expect(data).toHaveProperty('BTC');
   });
 
   test('fetchTicker', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT' } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchTicker(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT' };
+    const { err, res } = await invoke(serviceImpl.fetchTicker, req);
     expect(err).toBeNull();
-    expect(res.data.symbol).toBe('BTC/USDT');
+    const data = (res as { data: { symbol: string } }).data;
+    expect(data.symbol).toBe('BTC/USDT');
   });
 
   test('fetchTickers', async () => {
-    const call: any = { request: { ...base, symbols: ['BTC/USDT', 'ETH/USDT'] } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchTickers(call, fakeCb(r)));
+    const req = { ...base, symbols: ['BTC/USDT', 'ETH/USDT'] };
+    const { err, res } = await invoke(serviceImpl.fetchTickers, req);
     expect(err).toBeNull();
-    expect(res.data['BTC/USDT'].last).toBe(65000);
+    const data = (res as { data: Record<string, { last: number }> }).data;
+    expect(data['BTC/USDT'].last).toBe(65000);
   });
 
   test('fetchOrderBook', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT', limit: 10 } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchOrderBook(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT', limit: 10 };
+    const { err, res } = await invoke(serviceImpl.fetchOrderBook, req);
     expect(err).toBeNull();
-    expect(res.data).toHaveProperty('bids');
+    const data = (res as { data: OrderBook }).data;
+    expect(Array.isArray(data.bids)).toBe(true);
   });
 
   test('fetchOHLCV', async () => {
-    const call: any = {
-      request: { ...base, symbol: 'BTC/USDT', timeframe: '1h', since: 0, limit: 1 },
-    };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchOHLCV(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT', timeframe: '1h', since: 0, limit: 1 };
+    const { err, res } = await invoke(serviceImpl.fetchOHLCV, req);
     expect(err).toBeNull();
-    expect(res.candles[0]).toHaveProperty('timestamp');
-    expect(res.candles[0]).toHaveProperty('open');
+    const candles = (res as { candles: OhlcvEntry[] }).candles;
+    expect(candles[0]).toHaveProperty('timestamp');
+    expect(candles[0]).toHaveProperty('open');
   });
 
-  test('fetchStatus (unimplemented path handled)', async () => {
-    // Our mock exchange implements fetchStatus; verify success path
-    const call: any = { request: base };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchStatus(call, fakeCb(r)));
+  test('fetchStatus', async () => {
+    const { err, res } = await invoke(serviceImpl.fetchStatus, base);
     expect(err).toBeNull();
-    expect(res.data.status).toBe('ok');
+    const data = (res as { data: { status: string } }).data;
+    expect(data.status).toBe('ok');
   });
 
   test('fetchTrades', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT', since: 0, limit: 1 } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchTrades(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT', since: 0, limit: 1 };
+    const { err, res } = await invoke(serviceImpl.fetchTrades, req);
     expect(err).toBeNull();
-    expect(Array.isArray(res.data)).toBe(true);
+    expect(Array.isArray((res as { data: JsonValue }).data)).toBe(true);
   });
 
   test('fetchBalance', async () => {
-    const { err, res } = await new Promise<any>((r) =>
-      serviceImpl.fetchBalance({ request: base } as any, fakeCb(r)),
-    );
+    const { err, res } = await invoke(serviceImpl.fetchBalance, base);
     expect(err).toBeNull();
-    expect(res.data.total.USDT).toBe(1000);
+    const data = (res as { data: { total: Record<string, number> } }).data;
+    expect(data.total.USDT).toBe(1000);
   });
 
   test('fetchOrder', async () => {
-    const call: any = { request: { ...base, id: 'o1', symbol: 'BTC/USDT' } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchOrder(call, fakeCb(r)));
+    const req = { ...base, id: 'o1', symbol: 'BTC/USDT' };
+    const { err, res } = await invoke(serviceImpl.fetchOrder, req);
     expect(err).toBeNull();
-    expect(res.data.id).toBe('o1');
+    expect((res as { data: { id: string } }).data.id).toBe('o1');
   });
 
   test('fetchOrders', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT', since: 0, limit: 10 } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchOrders(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT', since: 0, limit: 10 };
+    const { err, res } = await invoke(serviceImpl.fetchOrders, req);
     expect(err).toBeNull();
-    expect(res.data.length).toBe(2);
+    expect(Array.isArray((res as { data: unknown[] }).data)).toBe(true);
   });
 
   test('fetchOpenOrders', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT' } };
-    const { err, res } = await new Promise<any>((r) =>
-      serviceImpl.fetchOpenOrders(call, fakeCb(r)),
-    );
+    const req = { ...base, symbol: 'BTC/USDT' };
+    const { err, res } = await invoke(serviceImpl.fetchOpenOrders, req);
     expect(err).toBeNull();
-    expect(res.data[0].status).toBe('open');
+    const arr = (res as { data: Array<{ id: string; status: string }> }).data;
+    expect(arr[0].status).toBe('open');
   });
 
   test('fetchClosedOrders', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT' } };
-    const { err, res } = await new Promise<any>((r) =>
-      serviceImpl.fetchClosedOrders(call, fakeCb(r)),
-    );
+    const req = { ...base, symbol: 'BTC/USDT' };
+    const { err, res } = await invoke(serviceImpl.fetchClosedOrders, req);
     expect(err).toBeNull();
-    expect(res.data[0].status).toBe('closed');
+    const arr = (res as { data: Array<{ id: string; status: string }> }).data;
+    expect(arr[0].status).toBe('closed');
   });
 
   test('fetchMyTrades', async () => {
-    const call: any = { request: { ...base, symbol: 'BTC/USDT' } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.fetchMyTrades(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT' };
+    const { err, res } = await invoke(serviceImpl.fetchMyTrades, req);
     expect(err).toBeNull();
-    expect(res.data[0].id).toBe('mt1');
+    const arr = (res as { data: Array<{ id: string; symbol: string }> }).data;
+    expect(arr[0].id).toBe('mt1');
   });
 
   test('createOrder', async () => {
-    const call: any = {
-      request: { ...base, symbol: 'BTC/USDT', type: 'limit', side: 'buy', amount: 1, price: 1 },
-    };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.createOrder(call, fakeCb(r)));
+    const req = { ...base, symbol: 'BTC/USDT', type: 'limit', side: 'buy', amount: 1, price: 1 };
+    const { err, res } = await invoke(serviceImpl.createOrder, req);
     expect(err).toBeNull();
-    expect(res.data.id).toBe('newOrder');
+    expect((res as { data: { id: string } }).data.id).toBe('newOrder');
   });
 
   test('cancelOrder', async () => {
-    const call: any = { request: { ...base, id: 'o1', symbol: 'BTC/USDT' } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.cancelOrder(call, fakeCb(r)));
+    const req = { ...base, id: 'o1', symbol: 'BTC/USDT' };
+    const { err, res } = await invoke(serviceImpl.cancelOrder, req);
     expect(err).toBeNull();
-    expect(res.data.status).toBe('canceled');
+    expect((res as { data: { status: string } }).data.status).toBe('canceled');
   });
 
-  test('deposit (unimplemented -> UNIMPLEMENTED)', async () => {
-    const call: any = { request: { ...base, code: 'USDT', amount: 1, address: 'addr' } };
-    const { err } = await new Promise<any>((r) => serviceImpl.deposit(call, fakeCb(r)));
+  test('deposit (UNIMPLEMENTED)', async () => {
+    const req = { ...base, code: 'USDT', amount: 1, address: 'addr' };
+    const { err } = await invoke(serviceImpl.deposit, req);
     expect(err).not.toBeNull();
-    expect(err.code).toBe(12); // status.UNIMPLEMENTED
+    expect((err as ServiceError).code).toBe(12); // status.UNIMPLEMENTED
   });
 
   test('withdraw', async () => {
-    const call: any = { request: { ...base, code: 'USDT', amount: 1, address: 'addr' } };
-    const { err, res } = await new Promise<any>((r) => serviceImpl.withdraw(call, fakeCb(r)));
+    const req = { ...base, code: 'USDT', amount: 1, address: 'addr' };
+    const { err, res } = await invoke(serviceImpl.withdraw, req);
     expect(err).toBeNull();
-    expect(res.data.id).toBe('w1');
+    expect((res as { data: { id: string } }).data.id).toBe('w1');
   });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules", "coverage"]
 }


### PR DESCRIPTION
## Description
Fixes lint errors with the exception of ones to be addressed by #6

## Implementation
bulk of errors:
- add imports and define custom classes as necessary to avoid using `any` as a return type, No `any` casts
- Safer error handling: handle `unknown`, maps to gRPC codes, and never leaks any.
- `src/index.ts`: wrapUnary makes each handler return void, eliminating @typescript-eslint/no-misused-promises
- other one-off / smaller volume errors

## Testing

` yarn fmt && yarn lint` :
note: still some lint issues in `index.ts` to be addressed in #6

```
➜  ccxt-micro git:(vikram.3.fix-lint-errors) ✗ yarn fmt
yarn run v1.22.19
$ prettier --write .
.github/ISSUE_TEMPLATE/bug_report.md 42ms (unchanged)
.github/ISSUE_TEMPLATE/feature_request.md 6ms (unchanged)
.prettierrc.json 28ms (unchanged)
eslint.config.ts 48ms (unchanged)
jest.config.ts 4ms (unchanged)
package.json 3ms (unchanged)
README.md 34ms (unchanged)
src/exchangeFactory.ts 16ms (unchanged)
src/index.ts 25ms (unchanged)
src/service.ts 43ms (unchanged)
src/types.ts 11ms (unchanged)
src/utils.ts 9ms (unchanged)
test/service.test.ts 42ms (unchanged)
tsconfig.eslint.json 1ms (unchanged)
tsconfig.json 1ms (unchanged)
Done in 0.51s.
```

```
➜  ccxt-micro git:(vikram.3.fix-lint-errors) ✗ yarn lint
yarn run v1.22.19
$ eslint .

/home/biya/projects/ccxt-micro/src/index.ts
  61:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  61:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  62:29  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  62:68  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  63:32  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  63:74  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  64:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  64:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  65:29  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  65:68  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  66:31  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  66:72  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  67:27  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  67:64  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  68:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  68:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  69:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  69:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  70:29  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  70:68  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  71:27  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  71:64  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  72:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  72:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  73:32  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  73:74  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  74:34  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  74:78  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  75:30  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  75:70  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  76:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  76:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  77:28  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  77:66  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  78:24  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  78:58  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any
  79:25  error    Unsafe argument of type `any` assigned to a parameter of type `(call: ServerUnaryCall<unknown, unknown>, cb: sendUnaryData<unknown>) => void | Promise<void>`  @typescript-eslint/no-unsafe-argument
  79:60  warning  Unexpected any. Specify a different type                                                                                                                       @typescript-eslint/no-explicit-any

✖ 38 problems (19 errors, 19 warnings)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```