### PR TITLE
[6] Use statc protobuf derived request and response classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ vite.config.ts.timestamp-*
 
 # Debian install files (from bootstrap script)
 *.deb
+
+# Generated files
+generated/

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Status codes:
 **Mock output:**
 `{ "data": { "bids": [[65000, 1]], "asks": [[65100, 2]] } }`
 
-### fetchOHLCV(OHLCVRequest) -> FetchOHLCVResponse
+### fetchOhlcv(OHLCVRequest) -> FetchOHLCVResponse
 
 **Params:** `symbol: string`, `timeframe?: string`, `since?: number`, `limit?: number`, `params?: object`  
 **Mock output:**

--- a/bootstrap
+++ b/bootstrap
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Installs all necessary packages necessary for development and testing
-# NOTE: assumes ubuntu / debian. To install docker, you may need to use a different package manager for your OS.
+# NOTE: assumes ubuntu / debian. To install docker and protoc, you may need to use a different package manager for your OS.
 
 # node / yarn
 
@@ -15,11 +15,14 @@ nvm install node -y
 nvm use node
 npm install -g yarn -y
 
-# install project dependencies
+# protobuf compiler
+sudo apt install protobuf-compiler -y
+
+# install project dependencies & generate protobufs (postinstall script)
 yarn
 
 # docker
 
 curl -O https://desktop.docker.com/linux/main/amd64/docker-desktop-amd64.deb
 sudo apt update
-sudo apt install ./docker-desktop-amd64.deb
+sudo apt install ./docker-desktop-amd64.deb -y

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,5 +5,6 @@ module.exports = {
   testMatch: ['**/test/**/*.test.ts'],
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['/src/generated/'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "lint:fix": "eslint . --fix",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
-    "presubmit": "yarn && yarn fmt && yarn lint:fix && yarn test"
+    "presubmit": "yarn && yarn fmt && yarn lint:fix && yarn test",
+    "proto:gen": "protoc --plugin=$(yarn bin)/protoc-gen-ts_proto --ts_proto_out=src/generated --ts_proto_opt=esModuleInterop=true,env=node,outputServices=grpc-js,outputJsonMethods=true -I proto proto/ccxt.proto",
+    "postinstall": "yarn proto:gen"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.11.2",
@@ -39,6 +41,7 @@
     "prettier-eslint": "^16.4.2",
     "ts-jest": "^29.1.2",
     "ts-node-dev": "^2.0.0",
+    "ts-proto": "^2.7.7",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.43.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,32 @@ function main(): void {
   const server = new grpc.Server();
   server.addService(CcxtServiceService, serviceImpl);
 
-  const port = process.env.PORT ? Number(process.env.PORT) : 50051;
+  const port = Number(process.env.PORT ?? 50051);
   const addr = `0.0.0.0:${port}`;
 
-  server.bindAsync(addr, grpc.ServerCredentials.createInsecure(), (err) => {
+  server.bindAsync(addr, grpc.ServerCredentials.createInsecure(), (err, boundPort) => {
     if (err) {
       console.error('Failed to bind:', err);
       process.exit(1);
     }
-    console.log(`ccxt-micro gRPC server listening on ${addr}`);
-    server.start();
+    // No server.start(): it’s deprecated & unnecessary in @grpc/grpc-js >= 1.10.x
+
+    console.log(`ccxt-micro gRPC server listening on 0.0.0.0:${boundPort}`);
   });
+
+  // Graceful shutdown
+  const shutdown = (signal: NodeJS.Signals) => {
+    console.log(`\nReceived ${signal}, shutting down gRPC server...`);
+    server.tryShutdown((shutdownErr) => {
+      if (shutdownErr) {
+        console.error('Error during gRPC shutdown, forcing:', shutdownErr);
+        server.forceShutdown();
+      }
+      process.exit(0);
+    });
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,85 +1,13 @@
 import * as grpc from '@grpc/grpc-js';
-import * as protoLoader from '@grpc/proto-loader';
-import path from 'path';
 import dotenv from 'dotenv';
+import { CcxtServiceService } from './generated/ccxt';
 import { serviceImpl } from './service';
-import { mapCcxtErrorToGrpc } from './utils';
 
 dotenv.config();
 
-const PROTO_PATH = path.resolve(__dirname, '../proto/ccxt.proto');
-
-const packageDef: protoLoader.PackageDefinition = protoLoader.loadSync(PROTO_PATH, {
-  keepCase: true,
-  longs: String,
-  enums: String,
-  defaults: true,
-  oneofs: true,
-});
-
-// Loaded packages are untyped; treat as a generic GrpcObject.
-const loaded: grpc.GrpcObject = grpc.loadPackageDefinition(packageDef);
-
-// Reach into our package and pull out the service definition, staying type-safe.
-const ccxtmicro = loaded.ccxtmicro as grpc.GrpcObject;
-const CcxtService = ccxtmicro.CcxtService as unknown as {
-  service: grpc.ServiceDefinition<grpc.UntypedServiceImplementation>;
-};
-
-/**
- * Wrap an async unary handler so it satisfies `handleUnaryCall`'s `void` return
- * and avoids `@typescript-eslint/no-misused-promises`.
- */
-function wrapUnary(
-  fn: (
-    call: grpc.ServerUnaryCall<unknown, unknown>,
-    cb: grpc.sendUnaryData<unknown>,
-  ) => Promise<void> | void,
-): grpc.handleUnaryCall<unknown, unknown> {
-  return (call, cb) => {
-    try {
-      const maybePromise = fn(call, cb);
-      if (maybePromise && typeof (maybePromise as Promise<unknown>).catch === 'function') {
-        void (maybePromise as Promise<unknown>).catch((e) => {
-          // Last-resort error path if handler threw before calling `cb`
-          const { code, message } = mapCcxtErrorToGrpc(e);
-          cb({ code, message } as never, null as never);
-        });
-      }
-    } catch (e) {
-      const { code, message } = mapCcxtErrorToGrpc(e);
-      cb({ code, message } as never, null as never);
-    }
-  };
-}
-
 function main(): void {
   const server = new grpc.Server();
-
-  // Provide an UntypedServiceImplementation with void-returning handlers.
-  const handlers: grpc.UntypedServiceImplementation = {
-    loadMarkets: wrapUnary(serviceImpl.loadMarkets as unknown as any),
-    fetchMarkets: wrapUnary(serviceImpl.fetchMarkets as unknown as any),
-    fetchCurrencies: wrapUnary(serviceImpl.fetchCurrencies as unknown as any),
-    fetchTicker: wrapUnary(serviceImpl.fetchTicker as unknown as any),
-    fetchTickers: wrapUnary(serviceImpl.fetchTickers as unknown as any),
-    fetchOrderBook: wrapUnary(serviceImpl.fetchOrderBook as unknown as any),
-    fetchOHLCV: wrapUnary(serviceImpl.fetchOHLCV as unknown as any),
-    fetchStatus: wrapUnary(serviceImpl.fetchStatus as unknown as any),
-    fetchTrades: wrapUnary(serviceImpl.fetchTrades as unknown as any),
-    fetchBalance: wrapUnary(serviceImpl.fetchBalance as unknown as any),
-    fetchOrder: wrapUnary(serviceImpl.fetchOrder as unknown as any),
-    fetchOrders: wrapUnary(serviceImpl.fetchOrders as unknown as any),
-    fetchOpenOrders: wrapUnary(serviceImpl.fetchOpenOrders as unknown as any),
-    fetchClosedOrders: wrapUnary(serviceImpl.fetchClosedOrders as unknown as any),
-    fetchMyTrades: wrapUnary(serviceImpl.fetchMyTrades as unknown as any),
-    createOrder: wrapUnary(serviceImpl.createOrder as unknown as any),
-    cancelOrder: wrapUnary(serviceImpl.cancelOrder as unknown as any),
-    deposit: wrapUnary(serviceImpl.deposit as unknown as any),
-    withdraw: wrapUnary(serviceImpl.withdraw as unknown as any),
-  };
-
-  server.addService(CcxtService.service, handlers);
+  server.addService(CcxtServiceService, serviceImpl);
 
   const port = process.env.PORT ? Number(process.env.PORT) : 50051;
   const addr = `0.0.0.0:${port}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export interface ExchangeLike {
   fetchTicker: (symbol: string, params?: Params) => Promise<JsonValue>;
   fetchTickers: (symbols?: readonly string[], params?: Params) => Promise<JsonValue>;
   fetchOrderBook: (symbol: string, limit?: number, params?: Params) => Promise<OrderBook>;
-  fetchOHLCV: (
+  fetchOhlcv: (
     symbol: string,
     timeframe?: string,
     since?: number,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,115 @@
 import { status } from '@grpc/grpc-js';
-import type { JsonValue, OhlcvEntry } from './types';
+import type { JsonValue, OhlcvEntry, Params } from './types';
+import type {
+  Value as ValueMsg,
+  Struct as StructMsg,
+  ListValue as ListValueMsg,
+} from './generated/google/protobuf/struct';
 
-/**
- * Map JS -> google.protobuf.Value-compatible.
- * Note: protobuf Value cannot carry `undefined`, so we coerce it to `null`.
- */
-export function asGrpcValue<T extends JsonValue>(data: T | undefined): T | null {
+/* ------------------------- small type guards (no any) ------------------------- */
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+function isStructMsg(x: unknown): x is StructMsg {
+  return isRecord(x) && 'fields' in x;
+}
+function isListValueMsg(x: unknown): x is ListValueMsg {
+  return typeof x === 'object' && x !== null && 'values' in (x as Record<string, unknown>);
+}
+
+/* ---------------------- Value <-> plain JSON conversions ---------------------- */
+
+// Plain JSON -> google.protobuf.Value (message shape)
+export function jsonToValue(j: JsonValue | null | undefined): ValueMsg {
+  if (j === null || j === undefined) return { nullValue: 0 } as ValueMsg;
+  const t = typeof j;
+  if (t === 'string') return { stringValue: j as string } as ValueMsg;
+  if (t === 'number') return { numberValue: j as number } as ValueMsg;
+  if (t === 'boolean') return { boolValue: j as boolean } as ValueMsg;
+
+  if (Array.isArray(j)) {
+    const values = (j as JsonValue[]).map((e) => jsonToValue(e));
+    // listValue can be either Value[] or a ListValue message depending on codegen.
+    // Use an `unknown` bridge to satisfy both variants without `any`.
+    return { listValue: values as unknown as ValueMsg['listValue'] } as ValueMsg;
+  }
+
+  const fields: Record<string, ValueMsg> = {};
+  for (const [k, v] of Object.entries(j as Record<string, JsonValue>)) {
+    fields[k] = jsonToValue(v);
+  }
+  return { structValue: { fields } } as ValueMsg;
+}
+
+// google.protobuf.Value (message) -> plain JSON
+function valueMsgToPlain(v: ValueMsg): JsonValue {
+  if (v.nullValue !== undefined) return null;
+  if (v.numberValue !== undefined) return v.numberValue;
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+
+  if (v.structValue !== undefined) {
+    return structMsgToPlain(v.structValue as StructMsg);
+  }
+
+  if (v.listValue !== undefined) {
+    const lvUnknown = v.listValue as unknown;
+    if (Array.isArray(lvUnknown)) {
+      const arr = lvUnknown as ValueMsg[];
+      return arr.map((x) => valueMsgToPlain(x));
+    }
+    if (isListValueMsg(lvUnknown)) {
+      const arr = lvUnknown.values ?? [];
+      return arr.map((x) => valueMsgToPlain(x as ValueMsg));
+    }
+    return [];
+  }
+
+  return null;
+}
+
+// Struct (message) -> plain Params (Record<string, JsonValue>)
+function structMsgToPlain(s: StructMsg): Params {
+  const out: Record<string, JsonValue> = {};
+  const fields = (s.fields ?? {}) as Record<string, ValueMsg | undefined>;
+  for (const [k, vv] of Object.entries(fields)) {
+    if (vv !== undefined) out[k] = valueMsgToPlain(vv);
+  }
+  return out;
+}
+
+/* ---------- Converters used by your service ---------- */
+
+// Accept Struct or plain object -> Params
+export function structToParams(s?: StructMsg | Record<string, unknown> | null): Params | undefined {
+  if (!s) return undefined;
+  if (isStructMsg(s)) return structMsgToPlain(s);
+  // Already a plain object; trust it matches Params (your ExchangeLike expects that)
+  return s as Params;
+}
+
+// runtime check for tests/debugging
+export function isProtoValue(v: unknown): v is ValueMsg {
+  if (!isRecord(v)) return false;
+  return (
+    'nullValue' in v ||
+    'numberValue' in v ||
+    'stringValue' in v ||
+    'boolValue' in v ||
+    'structValue' in v ||
+    'listValue' in v
+  );
+}
+
+/** Map JS -> Value-compatible JSON (undefined becomes null for protobuf). */
+export function asGrpcValue<T extends JsonValue | null | undefined>(data: T): JsonValue | null {
   return data === undefined ? null : data;
 }
 
 type ErrorLike = { name?: unknown; message?: unknown };
 
-/** Convert a thrown value to gRPC status + message without using `any`. */
 export function mapCcxtErrorToGrpc(err: unknown): { code: number; message: string } {
-  const { name, message } =
-    typeof err === 'object' && err !== null ? (err as ErrorLike) : ({} as ErrorLike);
-
+  const { name, message } = isRecord(err) ? (err as ErrorLike) : ({} as ErrorLike);
   const nameStr = typeof name === 'string' ? name : '';
   const msgStr = typeof message === 'string' ? message : 'Unknown error';
 

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -1,16 +1,45 @@
 // test/service.test.ts
 import { serviceImpl } from '../src/service';
-import type {
-  ExchangeConfig,
-  Credentials,
-  ExchangeLike,
-  JsonValue,
-  Params,
-  OhlcvEntry,
-  OrderBook,
-  OhlcvTuple,
-} from '../src/types';
+import type { ExchangeLike, JsonValue, Params, OrderBook, OhlcvTuple } from '../src/types';
+import { isProtoValue } from '../src/utils';
 import type { ServerUnaryCall, sendUnaryData, ServiceError } from '@grpc/grpc-js';
+
+import {
+  BaseRequest,
+  LoadMarketsRequest,
+  SymbolRequest,
+  SymbolsRequest,
+  OrderBookRequest,
+  OHLCVRequest,
+  TradesRequest,
+  BalanceRequest,
+  FetchOrderRequest,
+  FetchOrdersRequest,
+  CreateOrderRequest,
+  CancelOrderRequest,
+  DepositRequest,
+  WithdrawRequest,
+  GenericResponse,
+  FetchOHLCVResponse,
+} from '../src/generated/ccxt';
+import {
+  Struct as StructMsg,
+  Value as ValueMsg,
+  ListValue as ListValueMsg,
+} from '../src/generated/google/protobuf/struct';
+
+// Plain-JSON shapes we expect after decoding google.protobuf.Value
+type Loaded = { loaded: boolean };
+type MarketsArr = Array<{ symbol: string }>;
+type Currencies = Record<string, unknown>;
+type Ticker = { symbol: string; last?: number };
+type TickerMap = Record<string, { last: number }>;
+type OrderBookJson = { bids: number[][]; asks: number[][] };
+type StatusObj = { status: string };
+type TradesArr = Array<{ id: string; price?: number; amount?: number; symbol?: string }>;
+type BalanceJson = { total: Record<string, number> };
+type OrderJson = { id: string; status?: string };
+type IdOnly = { id: string };
 
 /* ----------------------------- Exchange mock ------------------------------ */
 
@@ -35,7 +64,7 @@ const mockExchange: ExchangeLike = {
       asks: [[65100, 2]] as Array<readonly [number, number]>,
     }),
   ),
-  fetchOHLCV: jest.fn(
+  fetchOhlcv: jest.fn(
     async (_s: string): Promise<readonly OhlcvTuple[]> => [
       [1710000000000, 60000, 66000, 59000, 65000, 120] as const,
     ],
@@ -69,10 +98,10 @@ const mockExchange: ExchangeLike = {
 };
 
 jest.mock('../src/exchangeFactory', () => {
+  const original = jest.requireActual('../src/exchangeFactory');
   return {
-    createExchange: jest.fn(
-      (_config: ExchangeConfig, _creds?: Credentials): ExchangeLike => mockExchange,
-    ),
+    ...original,
+    createExchange: jest.fn((): ExchangeLike => mockExchange),
   };
 });
 
@@ -98,154 +127,367 @@ function invoke<Req extends object, Res>(
   });
 }
 
+/* ----------------------------- Type guards ----------------------------- */
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+function has<K extends string>(
+  k: K,
+  o: unknown,
+): o is Record<K, unknown> & Record<string, unknown> {
+  return isRecord(o) && k in o;
+}
+function isStructMsg(x: unknown): x is StructMsg {
+  return isRecord(x) && 'fields' in x;
+}
+function isListValueMsg(x: unknown): x is ListValueMsg {
+  return isRecord(x) && 'values' in x;
+}
+
+/* ---------------------- Flatten Value -> plain JSON --------------------- */
+function valueMsgToPlain(v: ValueMsg): unknown {
+  // NOTE: check explicit undefined to avoid narrowing mishaps
+  if (v.nullValue !== undefined) return null;
+  if (v.numberValue !== undefined) return v.numberValue;
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+
+  // structValue may be a Struct message
+  if (v.structValue !== undefined) {
+    return structLikeToPlain(v.structValue);
+  }
+
+  // listValue may be a ListValue message OR already a Value[]
+  if (v.listValue !== undefined) {
+    return listLikeToPlain(v.listValue);
+  }
+
+  // Fallback: some generators keep a oneof wrapper-style; handle message-shaped objects
+  if (has('structValue', v) && v.structValue !== undefined) {
+    return structLikeToPlain(v.structValue);
+  }
+  if (has('listValue', v) && v.listValue !== undefined) {
+    return listLikeToPlain(v.listValue);
+  }
+
+  return undefined;
+}
+
+function structLikeToPlain(s: StructMsg | Record<string, unknown>): Record<string, unknown> {
+  // Normal case: Struct message { fields: Record<string, Value> }
+  if (isStructMsg(s)) {
+    const out: Record<string, unknown> = {};
+    const fields = s.fields ?? {};
+    for (const [k, vv] of Object.entries(fields)) {
+      if (vv !== undefined) out[k] = valueMsgToPlain(vv as ValueMsg);
+    }
+    return out;
+  }
+
+  // Extremely defensive: if it's already a plain record, shallow copy
+  if (isRecord(s)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(s)) out[k] = v;
+    return out;
+  }
+
+  return {};
+}
+
+function listLikeToPlain(lv: ListValueMsg | ValueMsg[] | unknown): unknown[] {
+  if (Array.isArray(lv)) {
+    // Already a Value[]
+    return lv.map((x) => valueMsgToPlain(x));
+  }
+  if (isListValueMsg(lv)) {
+    // Proper ListValue message
+    const arr = lv.values ?? [];
+    return arr.map((x) => valueMsgToPlain(x));
+  }
+  // Defensive: if someone passed an iterator function by mistake, just empty
+  return [];
+}
+
+/** Convert google.protobuf.Value message to plain JSON for assertions. */
+function valueTo<T>(v: ValueMsg | undefined): T {
+  const msg: ValueMsg = v ?? ({ nullValue: 0 } as ValueMsg);
+  return valueMsgToPlain(msg) as T;
+}
+
 /* --------------------------------- Fixtures -------------------------------- */
 
-const base = {
-  config: { exchange: 'mockex', enable_rate_limit: true },
-  credentials: { api_key: 'k', secret: 's' },
-  params: { value: {} as Params },
-} as const;
+const base: BaseRequest = BaseRequest.fromPartial({
+  config: { exchange: 'mockex', enableRateLimit: true },
+  credentials: { apiKey: 'k', secret: 's' },
+});
 
 /* ---------------------------------- Tests ---------------------------------- */
 
 describe('CcxtServiceImpl', () => {
   test('loadMarkets', async () => {
-    const req = { ...base, reload: true };
-    const { err, res } = await invoke(serviceImpl.loadMarkets, req);
+    const req: LoadMarketsRequest = LoadMarketsRequest.fromPartial({
+      ...base,
+      reload: true,
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<LoadMarketsRequest, GenericResponse>(
+      serviceImpl.loadMarkets,
+      req,
+    );
+    expect(isProtoValue((res as GenericResponse).data)).toBe(true);
     expect(err).toBeNull();
-    expect((res as { data: JsonValue }).data).toHaveProperty('loaded', true);
+    const data = valueTo<Loaded>((res as GenericResponse).data);
+    expect(data.loaded).toBe(true);
   });
 
   test('fetchMarkets', async () => {
-    const { err, res } = await invoke(serviceImpl.fetchMarkets, base);
+    const req: BaseRequest = BaseRequest.fromPartial({
+      ...base,
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<BaseRequest, GenericResponse>(serviceImpl.fetchMarkets, req);
     expect(err).toBeNull();
-    expect(Array.isArray((res as { data: JsonValue }).data)).toBe(true);
+    const data = valueTo<MarketsArr>((res as GenericResponse).data);
+    expect(Array.isArray(data)).toBe(true);
   });
 
   test('fetchCurrencies', async () => {
-    const { err, res } = await invoke(serviceImpl.fetchCurrencies, base);
+    const req: BaseRequest = BaseRequest.fromPartial({
+      ...base,
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<BaseRequest, GenericResponse>(
+      serviceImpl.fetchCurrencies,
+      req,
+    );
     expect(err).toBeNull();
-    const data = (res as { data: Record<string, unknown> }).data;
-    expect(data).toHaveProperty('BTC');
+    const data = valueTo<Currencies>((res as GenericResponse).data);
+    expect(Object.prototype.hasOwnProperty.call(data, 'BTC')).toBe(true);
   });
 
   test('fetchTicker', async () => {
-    const req = { ...base, symbol: 'BTC/USDT' };
-    const { err, res } = await invoke(serviceImpl.fetchTicker, req);
+    const req: SymbolRequest = SymbolRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<SymbolRequest, GenericResponse>(serviceImpl.fetchTicker, req);
     expect(err).toBeNull();
-    const data = (res as { data: { symbol: string } }).data;
+    const data = valueTo<Ticker>((res as GenericResponse).data);
     expect(data.symbol).toBe('BTC/USDT');
   });
 
   test('fetchTickers', async () => {
-    const req = { ...base, symbols: ['BTC/USDT', 'ETH/USDT'] };
-    const { err, res } = await invoke(serviceImpl.fetchTickers, req);
+    const req: SymbolsRequest = SymbolsRequest.fromPartial({
+      ...base,
+      symbols: ['BTC/USDT', 'ETH/USDT'],
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<SymbolsRequest, GenericResponse>(
+      serviceImpl.fetchTickers,
+      req,
+    );
     expect(err).toBeNull();
-    const data = (res as { data: Record<string, { last: number }> }).data;
+    const data = valueTo<TickerMap>((res as GenericResponse).data);
     expect(data['BTC/USDT'].last).toBe(65000);
   });
 
   test('fetchOrderBook', async () => {
-    const req = { ...base, symbol: 'BTC/USDT', limit: 10 };
-    const { err, res } = await invoke(serviceImpl.fetchOrderBook, req);
+    const req: OrderBookRequest = OrderBookRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+      limit: 10,
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<OrderBookRequest, GenericResponse>(
+      serviceImpl.fetchOrderBook,
+      req,
+    );
     expect(err).toBeNull();
-    const data = (res as { data: OrderBook }).data;
+    const data = valueTo<OrderBookJson>((res as GenericResponse).data);
     expect(Array.isArray(data.bids)).toBe(true);
   });
 
-  test('fetchOHLCV', async () => {
-    const req = { ...base, symbol: 'BTC/USDT', timeframe: '1h', since: 0, limit: 1 };
-    const { err, res } = await invoke(serviceImpl.fetchOHLCV, req);
+  test('fetchOhlcv', async () => {
+    const req: OHLCVRequest = OHLCVRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+      timeframe: '1h',
+      since: 0,
+      limit: 1,
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<OHLCVRequest, FetchOHLCVResponse>(
+      serviceImpl.fetchOhlcv,
+      req,
+    );
     expect(err).toBeNull();
-    const candles = (res as { candles: OhlcvEntry[] }).candles;
+    const candles = (res as FetchOHLCVResponse).candles;
     expect(candles[0]).toHaveProperty('timestamp');
     expect(candles[0]).toHaveProperty('open');
   });
 
   test('fetchStatus', async () => {
-    const { err, res } = await invoke(serviceImpl.fetchStatus, base);
+    const req: BaseRequest = BaseRequest.fromPartial({ ...base });
+    const { err, res } = await invoke<BaseRequest, GenericResponse>(serviceImpl.fetchStatus, req);
     expect(err).toBeNull();
-    const data = (res as { data: { status: string } }).data;
+    const data = valueTo<StatusObj>((res as GenericResponse).data);
     expect(data.status).toBe('ok');
   });
 
   test('fetchTrades', async () => {
-    const req = { ...base, symbol: 'BTC/USDT', since: 0, limit: 1 };
-    const { err, res } = await invoke(serviceImpl.fetchTrades, req);
+    const req: TradesRequest = TradesRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+      since: 0,
+      limit: 1,
+      params: { value: StructMsg.fromJSON({}) },
+    });
+    const { err, res } = await invoke<TradesRequest, GenericResponse>(serviceImpl.fetchTrades, req);
     expect(err).toBeNull();
-    expect(Array.isArray((res as { data: JsonValue }).data)).toBe(true);
+    const data = valueTo<TradesArr>((res as GenericResponse).data);
+    expect(Array.isArray(data)).toBe(true);
   });
 
   test('fetchBalance', async () => {
-    const { err, res } = await invoke(serviceImpl.fetchBalance, base);
+    const req: BalanceRequest = BalanceRequest.fromPartial({ ...base });
+    const { err, res } = await invoke<BalanceRequest, GenericResponse>(
+      serviceImpl.fetchBalance,
+      req,
+    );
     expect(err).toBeNull();
-    const data = (res as { data: { total: Record<string, number> } }).data;
+    const data = valueTo<BalanceJson>((res as GenericResponse).data);
     expect(data.total.USDT).toBe(1000);
   });
 
   test('fetchOrder', async () => {
-    const req = { ...base, id: 'o1', symbol: 'BTC/USDT' };
-    const { err, res } = await invoke(serviceImpl.fetchOrder, req);
+    const req: FetchOrderRequest = FetchOrderRequest.fromPartial({
+      ...base,
+      id: 'o1',
+      symbol: 'BTC/USDT',
+    });
+    const { err, res } = await invoke<FetchOrderRequest, GenericResponse>(
+      serviceImpl.fetchOrder,
+      req,
+    );
     expect(err).toBeNull();
-    expect((res as { data: { id: string } }).data.id).toBe('o1');
+    const data = valueTo<OrderJson>((res as GenericResponse).data);
+    expect(data.id).toBe('o1');
   });
 
   test('fetchOrders', async () => {
-    const req = { ...base, symbol: 'BTC/USDT', since: 0, limit: 10 };
-    const { err, res } = await invoke(serviceImpl.fetchOrders, req);
+    const req: FetchOrdersRequest = FetchOrdersRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+      since: 0,
+      limit: 10,
+    });
+    const { err, res } = await invoke<FetchOrdersRequest, GenericResponse>(
+      serviceImpl.fetchOrders,
+      req,
+    );
     expect(err).toBeNull();
-    expect(Array.isArray((res as { data: unknown[] }).data)).toBe(true);
+    const data = valueTo<unknown[]>((res as GenericResponse).data);
+    expect(Array.isArray(data)).toBe(true);
   });
 
   test('fetchOpenOrders', async () => {
-    const req = { ...base, symbol: 'BTC/USDT' };
-    const { err, res } = await invoke(serviceImpl.fetchOpenOrders, req);
+    const req: FetchOrdersRequest = FetchOrdersRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+    });
+    const { err, res } = await invoke<FetchOrdersRequest, GenericResponse>(
+      serviceImpl.fetchOpenOrders,
+      req,
+    );
     expect(err).toBeNull();
-    const arr = (res as { data: Array<{ id: string; status: string }> }).data;
+    const arr = valueTo<Array<OrderJson>>((res as GenericResponse).data);
     expect(arr[0].status).toBe('open');
   });
 
   test('fetchClosedOrders', async () => {
-    const req = { ...base, symbol: 'BTC/USDT' };
-    const { err, res } = await invoke(serviceImpl.fetchClosedOrders, req);
+    const req: FetchOrdersRequest = FetchOrdersRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+    });
+    const { err, res } = await invoke<FetchOrdersRequest, GenericResponse>(
+      serviceImpl.fetchClosedOrders,
+      req,
+    );
     expect(err).toBeNull();
-    const arr = (res as { data: Array<{ id: string; status: string }> }).data;
+    const arr = valueTo<Array<OrderJson>>((res as GenericResponse).data);
     expect(arr[0].status).toBe('closed');
   });
 
   test('fetchMyTrades', async () => {
-    const req = { ...base, symbol: 'BTC/USDT' };
-    const { err, res } = await invoke(serviceImpl.fetchMyTrades, req);
+    const req: FetchOrdersRequest = FetchOrdersRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+    });
+    const { err, res } = await invoke<FetchOrdersRequest, GenericResponse>(
+      serviceImpl.fetchMyTrades,
+      req,
+    );
     expect(err).toBeNull();
-    const arr = (res as { data: Array<{ id: string; symbol: string }> }).data;
+    const arr = valueTo<Array<{ id: string; symbol: string }>>((res as GenericResponse).data);
     expect(arr[0].id).toBe('mt1');
   });
 
   test('createOrder', async () => {
-    const req = { ...base, symbol: 'BTC/USDT', type: 'limit', side: 'buy', amount: 1, price: 1 };
-    const { err, res } = await invoke(serviceImpl.createOrder, req);
+    const req: CreateOrderRequest = CreateOrderRequest.fromPartial({
+      ...base,
+      symbol: 'BTC/USDT',
+      type: 'limit',
+      side: 'buy',
+      amount: 1,
+      price: 1,
+    });
+    const { err, res } = await invoke<CreateOrderRequest, GenericResponse>(
+      serviceImpl.createOrder,
+      req,
+    );
     expect(err).toBeNull();
-    expect((res as { data: { id: string } }).data.id).toBe('newOrder');
+    const data = valueTo<IdOnly>((res as GenericResponse).data);
+    expect(data.id).toBe('newOrder');
   });
 
   test('cancelOrder', async () => {
-    const req = { ...base, id: 'o1', symbol: 'BTC/USDT' };
-    const { err, res } = await invoke(serviceImpl.cancelOrder, req);
+    const req: CancelOrderRequest = CancelOrderRequest.fromPartial({
+      ...base,
+      id: 'o1',
+      symbol: 'BTC/USDT',
+    });
+    const { err, res } = await invoke<CancelOrderRequest, GenericResponse>(
+      serviceImpl.cancelOrder,
+      req,
+    );
     expect(err).toBeNull();
-    expect((res as { data: { status: string } }).data.status).toBe('canceled');
+    const data = valueTo<{ status: string }>((res as GenericResponse).data);
+    expect(data.status).toBe('canceled');
   });
 
   test('deposit (UNIMPLEMENTED)', async () => {
-    const req = { ...base, code: 'USDT', amount: 1, address: 'addr' };
-    const { err } = await invoke(serviceImpl.deposit, req);
+    const req: DepositRequest = DepositRequest.fromPartial({
+      ...base,
+      code: 'USDT',
+      amount: 1,
+      address: 'addr',
+    });
+    const { err } = await invoke<DepositRequest, GenericResponse>(serviceImpl.deposit, req);
     expect(err).not.toBeNull();
     expect((err as ServiceError).code).toBe(12); // status.UNIMPLEMENTED
   });
 
   test('withdraw', async () => {
-    const req = { ...base, code: 'USDT', amount: 1, address: 'addr' };
-    const { err, res } = await invoke(serviceImpl.withdraw, req);
+    const req: WithdrawRequest = WithdrawRequest.fromPartial({
+      ...base,
+      code: 'USDT',
+      amount: 1,
+      address: 'addr',
+    });
+    const { err, res } = await invoke<WithdrawRequest, GenericResponse>(serviceImpl.withdraw, req);
     expect(err).toBeNull();
-    expect((res as { data: { id: string } }).data.id).toBe('w1');
+    const data = valueTo<IdOnly>((res as GenericResponse).data);
+    expect(data.id).toBe('w1');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,6 +270,11 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bufbuild/protobuf@^2.0.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@bufbuild/protobuf/-/protobuf-2.8.0.tgz#88fcbcfa4735b88d882c7a3218c4403cf7ce3eee"
+  integrity sha512-r1/0w5C9dkbcdjyxY8ZHsC5AOWg4Pnzhm2zu7LO4UHSounp2tMm6Y+oioV9zlGbLveE7YaWRDUk48WLxRDgoqg==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
@@ -1346,6 +1351,11 @@ caniuse-lite@^1.0.30001741:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001741.tgz"
   integrity sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==
 
+case-anything@^2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/case-anything/-/case-anything-2.1.13.tgz#0cdc16278cb29a7fcdeb072400da3f342ba329e9"
+  integrity sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==
+
 ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz"
@@ -1519,6 +1529,11 @@ dequal@^2.0.0:
   resolved "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
 
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
@@ -1564,6 +1579,13 @@ dotenv@^16.4.5:
   version "16.6.1"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
+
+dprint-node@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/dprint-node/-/dprint-node-1.0.8.tgz#a02470722d8208a7d7eb3704328afda1d6758625"
+  integrity sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==
+  dependencies:
+    detect-libc "^1.0.3"
 
 dynamic-dedupe@^0.3.0:
   version "0.3.0"
@@ -3817,6 +3839,30 @@ ts-node@^10.4.0:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+ts-poet@^6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ts-poet/-/ts-poet-6.12.0.tgz#f28eb91778fdff8e1b264600c7ddddb40cd39d84"
+  integrity sha512-xo+iRNMWqyvXpFTaOAvLPA5QAWO6TZrSUs5s4Odaya3epqofBu/fMLHEWl8jPmjhA0s9sgj9sNvF1BmaQlmQkA==
+  dependencies:
+    dprint-node "^1.0.8"
+
+ts-proto-descriptors@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ts-proto-descriptors/-/ts-proto-descriptors-2.0.0.tgz#3a0e301a91cc6e932ac8dd13f7e07caa8a032c43"
+  integrity sha512-wHcTH3xIv11jxgkX5OyCSFfw27agpInAd6yh89hKG6zqIXnjW9SYqSER2CVQxdPj4czeOhGagNvZBEbJPy7qkw==
+  dependencies:
+    "@bufbuild/protobuf" "^2.0.0"
+
+ts-proto@^2.7.7:
+  version "2.7.7"
+  resolved "https://registry.yarnpkg.com/ts-proto/-/ts-proto-2.7.7.tgz#a30f164b3dc65123816fe0f6af4a7bd7caf99d75"
+  integrity sha512-/OfN9/Yriji2bbpOysZ/Jzc96isOKz+eBTJEcKaIZ0PR6x1TNgVm4Lz0zfbo+J0jwFO7fJjJyssefBPQ0o1V9A==
+  dependencies:
+    "@bufbuild/protobuf" "^2.0.0"
+    case-anything "^2.1.13"
+    ts-poet "^6.12.0"
+    ts-proto-descriptors "2.0.0"
 
 tsconfig@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
## Description

Use static classes for requests and responses generated from protobufs

## Impl

- add `yarn proto:gen` script, update bootstrap script to include protobuf compiler
- added helpers in `utils.ts` and `service.ts` to help with data wrangling between protobufs and JSON
- refactor `ServiceImpl` to use generated protobuf classes
- simplify `index.ts` to use generated service handler
- wrestle with eslint rules to avoid 'any', we typed strong af

## Tests

`yarn presubmit` passes! :tada: 

```
➜  ccxt-micro git:(vikram.6.static-req-resp-from-proto) ✗ yarn presubmit
yarn run v1.22.19
$ yarn && yarn fmt && yarn lint:fix && yarn test
[1/4] Resolving packages...
success Already up-to-date.
$ yarn proto:gen
$ protoc --plugin=$(yarn bin)/protoc-gen-ts_proto --ts_proto_out=src/generated --ts_proto_opt=esModuleInterop=true,env=node,outputServices=grpc-js,outputJsonMethods=true -I proto proto/ccxt.proto
$ prettier --write .
.github/ISSUE_TEMPLATE/bug_report.md 42ms (unchanged)
.github/ISSUE_TEMPLATE/feature_request.md 6ms (unchanged)
.prettierrc.json 25ms (unchanged)
eslint.config.ts 53ms (unchanged)
jest.config.ts 4ms (unchanged)
package.json 2ms (unchanged)
README.md 37ms (unchanged)
src/exchangeFactory.ts 19ms (unchanged)
src/index.ts 13ms (unchanged)
src/service.ts 74ms (unchanged)
src/types.ts 14ms (unchanged)
src/utils.ts 26ms (unchanged)
test/service.test.ts 64ms (unchanged)
tsconfig.eslint.json 1ms (unchanged)
tsconfig.json 1ms (unchanged)
$ eslint . --fix
$ jest --runInBand
 PASS  test/service.test.ts
  CcxtServiceImpl
    ✓ loadMarkets (3 ms)
    ✓ fetchMarkets (1 ms)
    ✓ fetchCurrencies
    ✓ fetchTicker (1 ms)
    ✓ fetchTickers
    ✓ fetchOrderBook (1 ms)
    ✓ fetchOhlcv (1 ms)
    ✓ fetchStatus
    ✓ fetchTrades (1 ms)
    ✓ fetchBalance
    ✓ fetchOrder (1 ms)
    ✓ fetchOrders
    ✓ fetchOpenOrders
    ✓ fetchClosedOrders
    ✓ fetchMyTrades
    ✓ createOrder (1 ms)
    ✓ cancelOrder
    ✓ deposit (UNIMPLEMENTED) (1 ms)
    ✓ withdraw

--------------------|---------|----------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------
File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                                                                           
--------------------|---------|----------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------
All files           |   51.34 |     30.1 |      60 |   53.87 |                                                                                                                                             
 exchangeFactory.ts |    7.14 |        0 |       0 |    9.52 | 26-57                                                                                                                                       
 index.ts           |       0 |        0 |       0 |       0 | 1-40                                                                                                                                        
 service.ts         |   69.75 |       40 |   63.33 |   69.75 | ...,116-118,132-134,147-149,163-165,176-186,191-193,207-209,222-224,237-239,253-255,269-271,285-287,301-303,317-319,332-334,357-363,377-379 
 utils.ts           |   45.23 |    37.14 |   66.66 |   48.43 | 17,46-68,76,88,112-127                                                                                                                      
--------------------|---------|----------|---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------
Test Suites: 1 passed, 1 total
Tests:       19 passed, 19 total
Snapshots:   0 total
Time:        3.69 s
Ran all test suites.
Done in 11.14s.
```