### PR TITLE
[9] Dockerfile with yarn, update protoc, add to scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,47 @@
-# Build stage
-FROM node:20-alpine AS build
+# ---------- Build stage ----------
+FROM node:24.8.0-alpine AS build
+
+# Needed for protoc & any native deps (build-only)
+RUN apk add --no-cache python3 make g++ protobuf-dev
+
+# Use Yarn via Corepack (no global npm install)
+RUN corepack enable && corepack prepare yarn@1.22.19 --activate
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install
+# Install deps first for caching
+COPY package.json yarn.lock ./
+# Skip scripts so postinstall (e.g., proto:gen) doesn't run yet
+RUN yarn install --frozen-lockfile --ignore-scripts
 
+# Project files
 COPY tsconfig.json ./
 COPY proto ./proto
 COPY src ./src
 
-RUN npm run build
+# Re-generate protobuf TS and build
+RUN rm -rf src/generated/
+RUN yarn proto:gen
+RUN yarn build
 
-# Production stage
-FROM node:20-alpine
+# ---------- Runtime stage ----------
+FROM node:24.8.0-alpine
 
 WORKDIR /app
-
 ENV NODE_ENV=production
 ENV PORT=50051
 
-COPY package.json ./
-RUN npm install --omit=dev
+# Corepack is included with Node; just enable it (no global yarn install)
+RUN corepack enable
 
+# Install only production deps (again, no scripts)
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile --ignore-scripts
+
+# Copy compiled output
 COPY --from=build /app/dist ./dist
-COPY proto ./proto
+# (proto files not needed at runtime, omit unless you want them)
+# COPY proto ./proto
 
 EXPOSE 50051
-
 CMD ["node", "dist/index.js"]

--- a/bootstrap
+++ b/bootstrap
@@ -16,7 +16,10 @@ nvm use node
 npm install -g yarn -y
 
 # protobuf compiler
-sudo apt install protobuf-compiler -y
+PB_REL="https://github.com/protocolbuffers/protobuf/releases"
+curl -LO $PB_REL/download/v32.1/protoc-32.1-linux-x86_64.zip
+unzip protoc-32.1-linux-x86_64.zip -d $HOME/.local
+export PATH="$PATH:$HOME/.local/bin"
 
 # install project dependencies & generate protobufs (postinstall script)
 yarn

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "lint:fix": "eslint . --fix",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
-    "presubmit": "yarn && yarn fmt && yarn lint:fix && yarn test",
-    "proto:gen": "protoc --plugin=$(yarn bin)/protoc-gen-ts_proto --ts_proto_out=src/generated --ts_proto_opt=esModuleInterop=true,env=node,outputServices=grpc-js,outputJsonMethods=true -I proto proto/ccxt.proto",
+    "presubmit": "yarn && yarn fmt && yarn lint:fix && yarn test && docker build -t ccxt-micro .",
+    "proto:gen": "mkdir -p src/generated && protoc --plugin=$(yarn bin)/protoc-gen-ts_proto --ts_proto_out=src/generated --ts_proto_opt=esModuleInterop=true,env=node,outputServices=grpc-js,outputJsonMethods=true -I proto proto/ccxt.proto",
     "postinstall": "yarn proto:gen"
   },
   "dependencies": {
@@ -23,7 +23,8 @@
     "@grpc/proto-loader": "^0.7.13",
     "ccxt": "^4.3.88",
     "dotenv": "^16.4.5",
-    "stable": "^0.1.8"
+    "stable": "^0.1.8",
+    "@bufbuild/protobuf": "^2.8.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,7 +270,7 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bufbuild/protobuf@^2.0.0":
+"@bufbuild/protobuf@^2.0.0", "@bufbuild/protobuf@^2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@bufbuild/protobuf/-/protobuf-2.8.0.tgz#88fcbcfa4735b88d882c7a3218c4403cf7ce3eee"
   integrity sha512-r1/0w5C9dkbcdjyxY8ZHsC5AOWg4Pnzhm2zu7LO4UHSounp2tMm6Y+oioV9zlGbLveE7YaWRDUk48WLxRDgoqg==


### PR DESCRIPTION
## Description
Closes #9 
Update dockerfile to work w/ yarn

## Impl

- rewrite dockerfile
- update protoc, update bootstrap script
- add dir safety to proto:gen script, add docker build to presubmit

## Testing
- build and run server with docker and other local yarn scripts:
```
➜  ccxt-micro git:(vikram.9.update-dockerfile-yarn) ✗ docker build -t ccxt-micro .                                               
[+] Building 15.6s (22/22) FINISHED                                                                                                                                                         docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.0s
 => => transferring dockerfile: 1.24kB                                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/node:24.8.0-alpine                                                                                                                                 0.6s
 => [internal] load .dockerignore                                                                                                                                                                     0.0s
 => => transferring context: 114B                                                                                                                                                                     0.0s
 => [build  1/12] FROM docker.io/library/node:24.8.0-alpine@sha256:3e843c608bb5232f39ecb2b25e41214b958b0795914707374c8acc28487dea17                                                                   0.0s
 => [internal] load build context                                                                                                                                                                     0.0s
 => => transferring context: 291.48kB                                                                                                                                                                 0.0s
 => CACHED [build  2/12] RUN apk add --no-cache python3 make g++ protobuf-dev                                                                                                                         0.0s
 => CACHED [build  3/12] RUN corepack enable && corepack prepare yarn@1.22.19 --activate                                                                                                              0.0s
 => CACHED [build  4/12] WORKDIR /app                                                                                                                                                                 0.0s
 => [build  5/12] COPY package.json yarn.lock ./                                                                                                                                                      0.1s
 => CACHED [stage-1 2/6] WORKDIR /app                                                                                                                                                                 0.0s
 => CACHED [stage-1 3/6] RUN corepack enable                                                                                                                                                          0.0s
 => [stage-1 4/6] COPY package.json yarn.lock ./                                                                                                                                                      0.1s
 => [build  6/12] RUN yarn install --frozen-lockfile --ignore-scripts                                                                                                                                 7.8s
 => [stage-1 5/6] RUN yarn install --production --frozen-lockfile --ignore-scripts                                                                                                                    6.9s
 => [build  7/12] COPY tsconfig.json ./                                                                                                                                                               0.1s
 => [build  8/12] COPY proto ./proto                                                                                                                                                                  0.1s
 => [build  9/12] COPY src ./src                                                                                                                                                                      0.1s
 => [build 10/12] RUN rm -rf src/generated/*                                                                                                                                                          0.2s
 => [build 11/12] RUN yarn proto:gen                                                                                                                                                                  0.9s
 => [build 12/12] RUN yarn build                                                                                                                                                                      2.8s
 => [stage-1 6/6] COPY --from=build /app/dist ./dist                                                                                                                                                  0.1s
 => exporting to image                                                                                                                                                                                2.6s
 => => exporting layers                                                                                                                                                                               2.5s
 => => writing image sha256:0b88d3f5c02c84f6c3bf099a597e7deb3278815c414d4a62a74d2f23284505c0                                                                                                          0.0s
 => => naming to docker.io/library/ccxt-micro                                                                                                                                                         0.0s
➜  ccxt-micro git:(vikram.9.update-dockerfile-yarn) ✗ docker run 0b88d3f5c02c84f6c3bf099a597e7deb3278815c414d4a62a74d2f23284505c0 
ccxt-micro gRPC server listening on 0.0.0.0:50051

^C
Received SIGINT, shutting down gRPC server...
➜  ccxt-micro git:(vikram.9.update-dockerfile-yarn) ✗ yarn start
yarn run v1.22.22
$ node dist/index.js
ccxt-micro gRPC server listening on 0.0.0.0:50051
(node:1630345) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
(Use `node --trace-deprecation ...` to show where the warning was created)
^C
➜  ccxt-micro git:(vikram.9.update-dockerfile-yarn) ✗ yarn dev
yarn run v1.22.22
$ ts-node-dev --respawn --transpile-only src/index.ts
[INFO] 02:52:28 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.2, typescript ver. 5.9.2)
ccxt-micro gRPC server listening on 0.0.0.0:50051
^C
Received SIGINT, shutting down gRPC server...
```